### PR TITLE
build: bump action runtime to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ inputs:
     description: 'Platform and arch of Zig to use.'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Bumps node to v20 [which is recommended](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)